### PR TITLE
RT#101692: add dependency on Test::SharedFork

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,7 @@ all_from 'lib/Test/Fake/HTTPD.pm';
 
 requires 'HTTP::Daemon';
 requires 'HTTP::Message::PSGI';
+requires 'Test::SharedFork' => '0.29';  # RT#101692
 requires 'Test::TCP';
 requires 'URI';
 requires 'Time::HiRes';


### PR DESCRIPTION
Add an explicit dependency on Test::SharedFork (that is used not directly but by Test::TCP) to avoid issues with the new Test::Builder.
See https://github.com/tokuhirom/Test-TCP/issues/32#event-222932574
