### PR TITLE
Add a new `host` option to support IPv6

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "NAKAGAWA Masaki <masaki@cpan.org>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.4, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.1.10, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -35,7 +35,7 @@
          "requires" : {
             "Test::CPAN::Meta" : "0",
             "Test::MinimumVersion::Fast" : "0.04",
-            "Test::PAUSE::Permissions" : "0.04",
+            "Test::PAUSE::Permissions" : "0.07",
             "Test::Pod" : "1.41",
             "Test::Spellunker" : "v0.2.7"
          }
@@ -81,7 +81,9 @@
    "x_authority" : "cpan:MASAKI",
    "x_contributors" : [
       "Olivier Mengué <dolmen@cpan.org>",
+      "Richard Hansen <rhansen@rhansen.org>",
       "ikasam_a <masaki.nakagawa@gmail.com>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27400"
+   "x_serialization_backend" : "JSON::PP version 2.27400_02",
+   "x_static_install" : 1
 }

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ DSL-style
         return [ 200, [ 'Content-Type' => 'text/plain' ], [ 'Hello World' ] ];
     };
 
-    printf "You can connect to your server at %s.\n", $httpd->host_port;
+    printf "Listening on address:port %s\n", $httpd->host_port;
     # or
-    printf "You can connect to your server at 127.0.0.1:%d.\n", $httpd->port;
+    printf "Listening on address %s port %s\n", $httpd->host, $httpd->port;
 
     # access to fake HTTP server
     use LWP::UserAgent;
@@ -70,7 +70,7 @@ Test::Fake::HTTPD is a fake HTTP server module for testing.
 
     Starts **HTTPS** server and returns the guard instance.
 
-    If you use this method, you MUST install [HTTP::Daemon::SSL](https://metacpan.org/pod/HTTP::Daemon::SSL).
+    If you use this method, you MUST install [HTTP::Daemon::SSL](https://metacpan.org/pod/HTTP%3A%3ADaemon%3A%3ASSL).
 
         extra_daemon_args
             SSL_key_file  => "certs/server-key.pem",
@@ -109,9 +109,13 @@ Test::Fake::HTTPD is a fake HTTP server module for testing.
 
         queue size for listen (default: 5)
 
+    - `host`
+
+        local address to listen on (default: 127.0.0.1)
+
     - `port`
 
-        local bind port number (default: auto detection)
+        TCP port to listen on (default: auto detection)
 
         my $httpd = Test::Fake::HTTPD->new(
             timeout => 10,
@@ -131,21 +135,27 @@ Test::Fake::HTTPD is a fake HTTP server module for testing.
 
         my $scheme = $httpd->scheme;
 
+- `host`
+
+    Returns the address the server is listening on.
+
 - `port`
 
-    Returns a port number of running.
+    Returns the TCP port the server is listening on.
 
         my $port = $httpd->port;
 
 - `host_port`
 
-    Returns a URI host\_port of running. ("127.0.0.1:{port}")
+    Returns the host:port from `endpoint` (e.g., "127.0.0.1:1234", "\[::1\]:1234").
 
         my $host_port = $httpd->host_port;
 
 - `endpoint`
 
-    Returns an endpoint URI of running. ("http://127.0.0.1:{port}" URI object)
+    Returns a URI object to the running server (e.g., "http://127.0.0.1:1234",
+    "https://\[::1\]:1234"). If `host` returns `undef`, `''`, `'0.0.0.0'`,
+    or `'::'`, the host portion of the URI is set to `localhost`.
 
         use LWP::UserAgent;
 
@@ -170,4 +180,4 @@ it under the same terms as Perl itself.
 
 # SEE ALSO
 
-[Test::TCP](https://metacpan.org/pod/Test::TCP), [HTTP::Daemon](https://metacpan.org/pod/HTTP::Daemon), [HTTP::Daemon::SSL](https://metacpan.org/pod/HTTP::Daemon::SSL), [HTTP::Message::PSGI](https://metacpan.org/pod/HTTP::Message::PSGI)
+[Test::TCP](https://metacpan.org/pod/Test%3A%3ATCP), [HTTP::Daemon](https://metacpan.org/pod/HTTP%3A%3ADaemon), [HTTP::Daemon::SSL](https://metacpan.org/pod/HTTP%3A%3ADaemon%3A%3ASSL), [HTTP::Message::PSGI](https://metacpan.org/pod/HTTP%3A%3AMessage%3A%3APSGI)

--- a/lib/Test/Fake/HTTPD.pm
+++ b/lib/Test/Fake/HTTPD.pm
@@ -42,7 +42,13 @@ if ($ENABLE_SSL) {
 
 sub new {
     my ($class, %args) = @_;
-    bless { timeout => 5, listen => 5, scheme => 'http', %args }, $class;
+    bless {
+        host => '127.0.0.1',
+        timeout => 5,
+        listen => 5,
+        scheme => 'http',
+        %args
+    }, $class;
 }
 
 our $DAEMON_MAP = {
@@ -63,13 +69,15 @@ sub run {
         : %EXTRA_DAEMON_ARGS;
 
     $self->{server} = Test::TCP->new(
+        ($self->host ? (host => $self->host) : ()),
         code => sub {
             my $port = shift;
 
             my $d;
             for (1..10) {
                 $d = $self->_daemon_class->new(
-                    LocalAddr => '127.0.0.1',
+                    # Note: IO::Socket::IP ignores LocalAddr if LocalHost is set.
+                    ($self->host ? (LocalAddr => $self->host) : ()),
                     LocalPort => $port,
                     Timeout   => $self->{timeout},
                     Proto     => 'tcp',
@@ -80,7 +88,10 @@ sub run {
                 Time::HiRes::sleep(0.1);
             }
 
-            croak("Can't accepted on 127.0.0.1:$port") unless $d;
+            croak(sprintf("failed to listen on address %s port %s%s",
+                          $self->host || '<default>',
+                          $self->port || '<default>',
+                          $@ eq '' ? '' : ": $@")) unless $d;
 
             $d->accept; # wait for port check from parent process
 
@@ -105,6 +116,11 @@ sub scheme {
     return $self->{scheme};
 }
 
+sub host {
+    my $self = shift;
+    return $self->{host};
+}
+
 sub port {
     my $self = shift;
     return $self->{server} ? $self->{server}->port : 0;
@@ -117,8 +133,12 @@ sub host_port {
 
 sub endpoint {
     my $self = shift;
-    my $url = sprintf '%s://127.0.0.1:%d', $self->scheme, $self->port;
-    return URI->new($url);
+    my $uri = URI->new($self->scheme . ':');
+    my $host = $self->host;
+    $host = 'localhost' if !defined($host) || $host eq '' || $host eq '0.0.0.0' || $host eq '::';
+    $uri->host($host);
+    $uri->port($self->port);
+    return $uri;
 }
 
 sub _is_win32 { $^O eq 'MSWin32' }
@@ -176,9 +196,9 @@ DSL-style
         return [ 200, [ 'Content-Type' => 'text/plain' ], [ 'Hello World' ] ];
     };
 
-    printf "You can connect to your server at %s.\n", $httpd->host_port;
+    printf "Listening on address:port %s\n", $httpd->host_port;
     # or
-    printf "You can connect to your server at 127.0.0.1:%d.\n", $httpd->port;
+    printf "Listening on address %s port %s\n", $httpd->host, $httpd->port;
 
     # access to fake HTTP server
     use LWP::UserAgent;
@@ -273,9 +293,13 @@ timeout value (default: 5)
 
 queue size for listen (default: 5)
 
+=item * C<host>
+
+local address to listen on (default: 127.0.0.1)
+
 =item * C<port>
 
-local bind port number (default: auto detection)
+TCP port to listen on (default: auto detection)
 
 =back
 
@@ -297,21 +321,27 @@ Returns a scheme of running, "http" or "https".
 
   my $scheme = $httpd->scheme;
 
+=item * C<host>
+
+Returns the address the server is listening on.
+
 =item * C<port>
 
-Returns a port number of running.
+Returns the TCP port the server is listening on.
 
   my $port = $httpd->port;
 
 =item * C<host_port>
 
-Returns a URI host_port of running. ("127.0.0.1:{port}")
+Returns the host:port from C<endpoint> (e.g., "127.0.0.1:1234", "[::1]:1234").
 
   my $host_port = $httpd->host_port;
 
 =item * C<endpoint>
 
-Returns an endpoint URI of running. ("http://127.0.0.1:{port}" URI object)
+Returns a URI object to the running server (e.g., "http://127.0.0.1:1234",
+"https://[::1]:1234"). If C<host> returns C<undef>, C<''>, C<'0.0.0.0'>,
+or C<'::'>, the host portion of the URI is set to C<localhost>.
 
   use LWP::UserAgent;
 


### PR DESCRIPTION
This option controls the address the server binds to. With recent versions of HTTP::Daemon, a user can set this to `::1` to allow IPv6 connections to localhost. (To accept both IPv4 and IPv6 connections, the user might also need to set HTTP::Daemon's `V6Only` option to false.)